### PR TITLE
Deletion of cells and renaming of tensorflow to pytorch

### DIFF
--- a/pytorch_alternatives/custom_pytorch_nlp/Headline Classifier Local.ipynb
+++ b/pytorch_alternatives/custom_pytorch_nlp/Headline Classifier Local.ipynb
@@ -150,24 +150,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df[\"CATEGORY\"][1]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "encoded_y[0]"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -186,24 +168,6 @@
    "outputs": [],
    "source": [
     "processed_docs, tokenizer = util.preprocessing.tokenize_and_pad_docs(df, \"TITLE\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df[\"TITLE\"][1]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "processed_docs[0]"
    ]
   },
   {
@@ -514,9 +478,9 @@
  "metadata": {
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (PyTorch 1.6 Python 3.6 CPU Optimized)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:ap-southeast-1:492261229750:image/pytorch-1.6-cpu-py36-ubuntu16.04-v1"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -528,7 +492,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.13"
+   "version": "3.9.5"
   }
  },
  "nbformat": 4,

--- a/pytorch_alternatives/custom_pytorch_nlp/Headline Classifier SageMaker.ipynb
+++ b/pytorch_alternatives/custom_pytorch_nlp/Headline Classifier SageMaker.ipynb
@@ -458,7 +458,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We have our `TensorFlow` estimator object, we have set the hyper-parameters for this object and we have our data channels linked with the algorithm. The only  remaining thing to do is to train the algorithm. The following command will train the algorithm. Training the algorithm involves a few steps. Firstly, the instance that we requested while creating the `TensorFlow` estimator classes is provisioned and is setup with the appropriate libraries. Then, the data from our channels are downloaded into the instance. Once this is done, the training job begins. The provisioning and data downloading will take some time, depending on the size of the data. \n",
+    "We have our `PyTorch` estimator object, we have set the hyper-parameters for this object and we have our data channels linked with the algorithm. The only  remaining thing to do is to train the algorithm. The following command will train the algorithm. Training the algorithm involves a few steps. Firstly, the instance that we requested while creating the `PyTorch` estimator classes is provisioned and is setup with the appropriate libraries. Then, the data from our channels are downloaded into the instance. Once this is done, the training job begins. The provisioning and data downloading will take some time, depending on the size of the data. \n",
     "\n",
     "Once the job has finished a \"Job complete\" message will be printed. The trained model can be found in the S3 bucket that was setup as `output_path` in the estimator."
    ]
@@ -767,9 +767,9 @@
  "metadata": {
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (PyTorch 1.6 Python 3.6 CPU Optimized)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:ap-southeast-1:492261229750:image/pytorch-1.6-cpu-py36-ubuntu16.04-v1"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -781,7 +781,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.13"
+   "version": "3.9.5"
   }
  },
  "nbformat": 4,

--- a/pytorch_alternatives/migration_challenge_pytorch_image/Local Notebook.ipynb
+++ b/pytorch_alternatives/migration_challenge_pytorch_image/Local Notebook.ipynb
@@ -622,9 +622,9 @@
  "metadata": {
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (PyTorch 1.6 Python 3.6 CPU Optimized)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:ap-southeast-1:492261229750:image/pytorch-1.6-cpu-py36-ubuntu16.04-v1"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -636,7 +636,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.13"
+   "version": "3.9.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Deleted cells under label encoding and tokenization to avoid confusion
The following section under Dummy encode the labels is a little confusing,
df['CATEGORY'][1] retrieves the dataframe with index = 1; as the dataframe has been randomized, index=1 does not refer to the second row and hence does not match with encoded_y

Renamed tensorflow to pytorch for pytorch alternative notebooks

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
