### PR TITLE
feat(nlp): migrate TF GloVe to FastText vectors

### DIFF
--- a/custom_tensorflow_keras_nlp/Headline Classifier Local.ipynb
+++ b/custom_tensorflow_keras_nlp/Headline Classifier Local.ipynb
@@ -240,7 +240,7 @@
    "source": [
     "### Import Word Embeddings\n",
     "\n",
-    "To represent our words in numeric form, we'll use pre-trained vector representations for each word in the vocabulary: In this case we'll be using pre-built GloVe word embeddings.\n",
+    "To represent our words in numeric form, we'll use pre-trained vector representations for each word in the vocabulary: In this case we'll be using [pre-trained word embeddings from FastText](https://fasttext.cc/docs/en/crawl-vectors.html), which are also available for a broad range of languages other than English.\n",
     "\n",
     "You could also explore training custom, domain-specific word embeddings using SageMaker's built-in [BlazingText algorithm](https://docs.aws.amazon.com/sagemaker/latest/dg/blazingtext.html). See the official [blazingtext_word2vec_text8 sample](https://github.com/awslabs/amazon-sagemaker-examples/tree/master/introduction_to_amazon_algorithms/blazingtext_word2vec_text8) for an example notebook showing how.\n"
    ]
@@ -340,8 +340,8 @@
    "source": [
     "model = Sequential()\n",
     "model.add(Embedding(\n",
-    "    vocab_size,\n",
-    "    100,\n",
+    "    embedding_matrix.shape[0],  # Final vocabulary size\n",
+    "    embedding_matrix.shape[1],  # Word vector dimensions\n",
     "    weights=[embedding_matrix],\n",
     "    input_length=40,\n",
     "    trainable=False,\n",

--- a/custom_tensorflow_keras_nlp/Headline Classifier SageMaker.ipynb
+++ b/custom_tensorflow_keras_nlp/Headline Classifier SageMaker.ipynb
@@ -240,7 +240,7 @@
    "source": [
     "### Import Word Embeddings\n",
     "\n",
-    "To represent our words in numeric form, we'll use pre-trained vector representations for each word in the vocabulary: In this case we'll be using pre-built GloVe word embeddings.\n",
+    "To represent our words in numeric form, we'll use pre-trained vector representations for each word in the vocabulary: In this case we'll be using [pre-trained word embeddings from FastText](https://fasttext.cc/docs/en/crawl-vectors.html), which are also available for a broad range of languages other than English.\n",
     "\n",
     "You could also explore training custom, domain-specific word embeddings using SageMaker's built-in [BlazingText algorithm](https://docs.aws.amazon.com/sagemaker/latest/dg/blazingtext.html). See the official [blazingtext_word2vec_text8 sample](https://github.com/awslabs/amazon-sagemaker-examples/tree/master/introduction_to_amazon_algorithms/blazingtext_word2vec_text8) for an example notebook showing how.\n"
    ]
@@ -454,7 +454,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hyperparameters = { \"epochs\": 5, \"vocab_size\": vocab_size, \"num_classes\": 4 }\n"
+    "hyperparameters = { \"epochs\": 5, \"max_seq_len\": 40, \"num_classes\": 4 }\n"
    ]
   },
   {
@@ -470,7 +470,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We will run the training job using a `ml.p3.2xlarge` instance (with GPU) to accelerate our training. If your account runs into resource limits please use a `ml.c5.xlarge` instance. "
+    "We will run the training job using a `ml.g4dn.xlarge` instance (with modest GPU) to accelerate our training. If your account runs into resource limits please try a `ml.c5.xlarge` (CPU-only) or `ml.p2.xlarge` (alternative GPU) instance type. "
    ]
   },
   {
@@ -481,22 +481,24 @@
    },
    "outputs": [],
    "source": [
+    "metric_definitions = [\n",
+    "    { \"Name\": \"loss\", \"Regex\": \"loss: ([0-9\\\\.]+)\" },\n",
+    "    { \"Name\": \"accuracy\", \"Regex\": \"acc: ([0-9\\\\.]+)\" },\n",
+    "    { \"Name\": \"validation:loss\", \"Regex\": \"Validation.*loss=([0-9\\\\.]+)\" },\n",
+    "    { \"Name\": \"validation:accuracy\", \"Regex\": \"Validation.*acc=([0-9\\\\.]+)\" },\n",
+    "]\n",
+    "\n",
     "estimator = TensorFlowEstimator(\n",
-    "    framework_version=\"1.14\",\n",
+    "    framework_version=\"1.15\",\n",
     "    py_version=\"py3\",\n",
     "    instance_count=1,\n",
-    "    instance_type=\"ml.p3.2xlarge\",\n",
+    "    instance_type=\"ml.g4dn.xlarge\",\n",
     "    role=role,\n",
     "    entry_point=\"main.py\",\n",
     "    source_dir=\"./src\",\n",
-    "    distributions={ \"parameter_server\": { \"enabled\": True } },\n",
+    "    distribution={ \"parameter_server\": { \"enabled\": True } },\n",
     "    hyperparameters=hyperparameters,\n",
-    "    metric_definitions=[\n",
-    "        { \"Name\": \"loss\", \"Regex\": \"loss: ([0-9\\\\.]+)\" },\n",
-    "        { \"Name\": \"accuracy\", \"Regex\": \"acc: ([0-9\\\\.]+)\" },\n",
-    "        { \"Name\": \"validation:loss\", \"Regex\": \"Validation.*loss=([0-9\\\\.]+)\" },\n",
-    "        { \"Name\": \"validation:accuracy\", \"Regex\": \"Validation.*acc=([0-9\\\\.]+)\" },\n",
-    "    ],\n",
+    "    metric_definitions=metric_definitions,\n",
     "    base_job_name=\"news-keras\",\n",
     "    max_run=20*60,  # Maximum allowed active runtime\n",
     "    use_spot_instances=True,  # Use spot instances to reduce cost\n",
@@ -654,9 +656,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "metric_definitions = [{ \"Name\": \"loss\", \"Regex\": \"loss: ([0-9\\\\.]+)\" }]\n",
-    "objective_metric_name = \"loss\"\n",
-    "objective_type = \"Minimize\"\n"
+    "# (See metric_definitions above)\n",
+    "objective_metric_name = \"validation:accuracy\"\n",
+    "objective_type = \"Maximize\"\n"
    ]
   },
   {

--- a/custom_tensorflow_keras_nlp/src/main.py
+++ b/custom_tensorflow_keras_nlp/src/main.py
@@ -33,7 +33,7 @@ def parse_args():
     parser.add_argument("--epochs", type=int, default=1)
     parser.add_argument("--learning_rate", type=float, default=0.001)
     parser.add_argument("--num_classes", type=int, default=4)
-    parser.add_argument("--vocab_size", type=int, default=300)
+    parser.add_argument("--max_seq_len", type=int, default=40)
 
     # Data, model, and output directories
     parser.add_argument("--output-data-dir", type=str, default=os.environ.get("SM_OUTPUT_DATA_DIR"))
@@ -60,10 +60,10 @@ if __name__ == "__main__":
     ###### Setup model architecture ############
     model = Sequential()
     model.add(Embedding(
-        args.vocab_size,
-        100,
+        embedding_matrix.shape[0],  # Final vocabulary size
+        embedding_matrix.shape[1],  # Word vector dimensions
         weights=[embedding_matrix],
-        input_length=40,
+        input_length=args.max_seq_len,
         trainable=False,
         name="embed",
     ))

--- a/custom_tensorflow_keras_nlp/util/preprocessing.py
+++ b/custom_tensorflow_keras_nlp/util/preprocessing.py
@@ -1,13 +1,15 @@
 from __future__ import division
 
 # Python Built-Ins:
+import gzip
 import os
 import re
 import shutil
 import subprocess
 import tarfile
+import time
+from typing import Optional
 import zipfile
-
 
 # External Dependencies:
 import numpy as np
@@ -17,24 +19,55 @@ from tensorflow.keras.preprocessing.text import Tokenizer
 from tensorflow.keras.preprocessing.sequence import pad_sequences
 from tensorflow.keras.utils import to_categorical
 
+
+def wait_for_file_stable(path: str, stable_secs: int=60, poll_secs: Optional[int]=None) -> bool:
+    """Wait for a file to become stable (not recently modified) & return existence
+
+    Returns False if file does not exist. Raises FileNotFoundError if file deleted during polling.
+
+    When running through the two notebooks at the same time in parallel, this helps to minimize any
+    errors caused by initiating multiple downloads/extractions/etc on the same file in parallel.
+    """
+    if not poll_secs:
+        poll_secs = stable_secs / 4
+    try:
+        init_stat = os.stat(path)
+    except FileNotFoundError:
+        return False
+
+    if (time.time() - init_stat.st_mtime) < stable_secs:
+        print(f"Waiting for file to stabilize... {path}")
+        while (time.time() - os.stat(path).st_mtime) < stable_secs:
+            time.sleep(poll_secs)
+        print("File ready")
+
+    return True
+
+
 def download_dataset():
     os.makedirs("data", exist_ok=True)
-    print("Downloading data...")
-    subprocess.call(
-        ["aws s3 cp s3://fast-ai-nlp/ag_news_csv.tgz data/ag_news_csv.tgz --no-sign-request"],
-        shell=True,
-    )
+    zip_filepath = os.path.join("data", "ag_news_csv.tgz")
 
-    with tarfile.open("data/ag_news_csv.tgz", 'r:gz') as tar:
+    if wait_for_file_stable(zip_filepath):
+        print("Using previously-downloaded dataset")
+    else:
+        print("Downloading data...")
+        subprocess.call(
+            [f"aws s3 cp s3://fast-ai-nlp/ag_news_csv.tgz {zip_filepath} --no-sign-request"],
+            shell=True,
+        )
+
+    with tarfile.open(zip_filepath, 'r:gz') as tar:
         print("Unzipping...")
-        tar.extractall(path="data/")
+        tar.extractall(path="data")
         tar.close()
     try:
         # Clean up the noise in the folder, don't care too much if it fails:
-        shutil.rmtree("data/__MACOSX/")
+        shutil.rmtree(os.path.join("data", "__MACOSX"))
     except:
         pass
     print("Saved to data/ folder")
+
 
 def dummy_encode_labels(df,label):
     encoder = preprocessing.LabelEncoder()
@@ -43,7 +76,8 @@ def dummy_encode_labels(df,label):
     dummy_y = to_categorical(encoded_y)
     return dummy_y, encoder.classes_
 
-def tokenize_pad_docs(df,columns):
+
+def tokenize_pad_docs(df, columns, max_length=40):
     docs = df[columns].values
     # prepare tokenizer
     t = Tokenizer()
@@ -52,47 +86,56 @@ def tokenize_pad_docs(df,columns):
     # integer encode the documents
     encoded_docs = t.texts_to_sequences(docs)
     print(f"Vocabulary size: {vocab_size}")
-    # pad documents to a max length of 4 words
-    max_length = 40
+    print("Padding docs to max_length={} (truncating {} docs)".format(
+        max_length,
+        sum(1 for doc in encoded_docs if len(doc) > max_length),
+    ))
     padded_docs = pad_sequences(encoded_docs, maxlen=max_length, padding="post")
     print(f"Number of headlines: {len(padded_docs)}")
     return padded_docs, t
 
-def get_word_embeddings(t, folder):
+
+def get_word_embeddings(t, folder, lang="en"):
+    """Download pre-trained word vectors and construct an embedding matrix for tokenizer `t`
+
+    Any tokens in `t` not found in the embedding vectors are mapped to all-zeros.
+    """
+    vecs_url = f"https://dl.fbaipublicfiles.com/fasttext/vectors-crawl/cc.{lang}.300.vec.gz"
+    vecs_gz_filename = vecs_url.rpartition("/")[2]
     os.makedirs(folder, exist_ok=True)
-    if os.path.isfile(f"{folder}/glove.6B.100d.txt"):
+    vecs_gz_filepath = os.path.join(folder, vecs_gz_filename)
+
+    # Tokenizer.num_words is nullable, and there's an OOV token, so:
+    tokenizer_vocab_size = len(t.word_index) + 1
+
+    if wait_for_file_stable(vecs_gz_filepath):
         print("Using existing embeddings file")
     else:
-        print("Downloading Glove word embeddings...")
-        subprocess.call(
-            [f"wget -O {folder}/glove.6B.zip http://nlp.stanford.edu/data/glove.6B.zip"],
-            shell=True,
-        )
-        with zipfile.ZipFile(f"{folder}/glove.6B.zip", "r") as zip_ref:
-            print("Unzipping...")
-            zip_ref.extractall(folder)
-
-        try:
-            # Remove unnecessary files, don't mind too much if fails:
-            for name in ["glove.6B.200d.txt", "glove.6B.50d.txt", "glove.6B.300d.txt", "glove.6B.zip"]:
-                os.remove(os.path.join(folder, name))
-        except:
-            pass
+        print("Downloading word vectors...")
+        subprocess.run([" ".join(["wget", "-NP", folder, vecs_url])], check=True, shell=True)
 
     print("Loading into memory...")
-    # load the whole embedding into memory
     embeddings_index = dict()
-    with open(f"{folder}/glove.6B.100d.txt", "r", encoding="utf-8") as f:
-        for line in f:
+    with gzip.open(vecs_gz_filepath, "rt") as zipf:
+        firstline = zipf.readline()
+        emb_vocab_size, emb_d = firstline.split(" ")
+        emb_vocab_size = int(emb_vocab_size)
+        emb_d = int(emb_d)
+        for line in zipf:
             values = line.split()
             word = values[0]
-            coefs = np.asarray(values[1:], dtype="float32")
-            embeddings_index[word] = coefs
-    vocab_size = len(embeddings_index)
-    print(f"Loaded {vocab_size} word vectors.")
+            # Only load subset of the embeddings recognised by the tokenizer:
+            if word in t.word_index:
+                coefs = np.asarray(values[1:], dtype="float32")
+                embeddings_index[word] = coefs
+    print("Loaded {} of {} word vectors for tokenizer vocabulary length {}".format(
+        len(embeddings_index),
+        emb_vocab_size,
+        tokenizer_vocab_size,
+    ))
 
     # create a weight matrix for words in training docs
-    embedding_matrix = np.zeros((vocab_size, 100))
+    embedding_matrix = np.zeros((tokenizer_vocab_size, emb_d))
     for word, i in t.word_index.items():
         embedding_vector = embeddings_index.get(word)
         if embedding_vector is not None:


### PR DESCRIPTION
*Issue #, if available:* #1

*Description of changes:*

In TF.Keras NLP notebooks:

- Migrate from GloVe 6B to pre-trained cc.en.300.vec.gz [from FastText](https://fasttext.cc/docs/en/crawl-vectors.html)
- Tweak default instance type to `ml.g4dn.xlarge`
- Add some mitigations to help prevent file corruptions/overwrite when running local & SageMaker notebooks in parallel
- Update default SageMaker training container TF v1.14->1.15, in line with the currently configured SMStudio kernel

FastText offers multi-lingual pre-trained embeddings (vs English-only) and marginally faster download time (although in current implementation this is offset by increases in downstream processing times)

PyTorch alternatives not yet updated, pending further testing.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
