### PR TITLE
Update model training job with c5.xlarge instance for NLP problem.

### DIFF
--- a/custom_tensorflow_keras_nlp/Headline Classifier SageMaker.ipynb
+++ b/custom_tensorflow_keras_nlp/Headline Classifier SageMaker.ipynb
@@ -462,7 +462,7 @@
     "\n",
     "Once the job has finished a \"Job complete\" message will be printed. The trained model can be found in the S3 bucket that was setup as `output_path` in the estimator.\n",
     "\n",
-    "In the lab, we will run a training job using a `ml.g4dn.xlarge` instance for model training, which provides faster deep learning model training experience. In case you encounter quota/capacity error(s), you can try `ml.c5.xlarge` instead. "
+    "In the lab, we will run a training job using `ml.c5.xlarge` instance for model training, which provides fast enough speed in our lab. Also, it's recommended to use GPU instances to speed up your model training.  "
    ]
   },
   {
@@ -473,6 +473,8 @@
    },
    "outputs": [],
    "source": [
+    "%%time\n",
+    "\n",
     "metric_definitions = [\n",
     "    { \"Name\": \"loss\", \"Regex\": \"loss: ([0-9\\\\.]+)\" },\n",
     "    { \"Name\": \"accuracy\", \"Regex\": \"acc: ([0-9\\\\.]+)\" },\n",
@@ -484,7 +486,7 @@
     "    framework_version=\"2.4\",\n",
     "    py_version=\"py37\",\n",
     "    instance_count=1,\n",
-    "    instance_type=\"ml.g4dn.xlarge\", # Or CPU-only \"ml.c5.xlarge\", if you see quota/capacity errors\n",
+    "    instance_type=\"ml.c5.xlarge\", \n",
     "    role=role,\n",
     "    entry_point=\"main.py\",\n",
     "    source_dir=\"./src\",\n",
@@ -766,7 +768,7 @@
   "kernelspec": {
    "display_name": "Python 3 (TensorFlow 2.3 Python 3.7 CPU Optimized)",
    "language": "python",
-   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:ap-southeast-1:492261229750:image/tensorflow-2.3-cpu-py37-ubuntu18.04-v1"
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:ap-southeast-2:452832661640:image/tensorflow-2.3-cpu-py37-ubuntu18.04-v1"
   },
   "language_info": {
    "codemirror_mode": {

--- a/pytorch_alternatives/custom_pytorch_nlp/Headline Classifier SageMaker.ipynb
+++ b/pytorch_alternatives/custom_pytorch_nlp/Headline Classifier SageMaker.ipynb
@@ -465,7 +465,7 @@
     "\n",
     "Once the job has finished a \"Job complete\" message will be printed. The trained model can be found in the S3 bucket that was setup as `output_path` in the estimator.\n",
     "\n",
-    "In the lab, we will run a training job using a `ml.g4dn.xlarge` instance for model training, which provides faster deep learning model training experience. In case you encounter quota/capacity error(s), you can try `ml.c5.xlarge` instead. "
+    "In the lab, we will run a training job using `ml.c5.xlarge` instance for model training, which provides fast enough speed in our lab. Also, it's recommended to use GPU instances to speed up your model training."
    ]
   },
   {
@@ -485,7 +485,7 @@
     "    framework_version=\"1.6\",\n",
     "    py_version=\"py3\",\n",
     "    instance_count=1,\n",
-    "    instance_type=\"ml.g4dn.xlarge\", # Or CPU-only \"ml.c5.xlarge\", if you see quota/capacity errors\n",
+    "    instance_type=\"ml.c5.xlarge\",\n",
     "    role=role,\n",
     "    entry_point=\"main.py\",\n",
     "    source_dir=\"./src\",\n",
@@ -770,9 +770,9 @@
  "metadata": {
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (PyTorch 1.6 Python 3.6 CPU Optimized)",
+   "display_name": "Python 3 (Data Science)",
    "language": "python",
-   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:ap-southeast-1:492261229750:image/pytorch-1.6-cpu-py36-ubuntu16.04-v1"
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:ap-southeast-2:452832661640:image/datascience-1.0"
   },
   "language_info": {
    "codemirror_mode": {
@@ -784,7 +784,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.13"
+   "version": "3.7.10"
   }
  },
  "nbformat": 4,

--- a/pytorch_alternatives/custom_pytorch_nlp/Headline Classifier SageMaker.ipynb
+++ b/pytorch_alternatives/custom_pytorch_nlp/Headline Classifier SageMaker.ipynb
@@ -770,9 +770,9 @@
  "metadata": {
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (Data Science)",
+   "display_name": "Python 3 (PyTorch 1.6 Python 3.6 CPU Optimized)",
    "language": "python",
-   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:ap-southeast-2:452832661640:image/datascience-1.0"
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:ap-southeast-2:452832661640:image/pytorch-1.6-cpu-py36-ubuntu16.04-v1"
   },
   "language_info": {
    "codemirror_mode": {
@@ -784,7 +784,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.6.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
*Issue #, if available:*
To update the instance type setting in Training Job with ml.c5.xlarge instance.

*Description of changes:*
GPU instances may no longer be supported in Event Engine, hence, switch the model training job instance type to ml.c5.xlarge instance.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
