### PR TITLE
Upgrade pandas/s3fs to fix errors in autopilot nb

### DIFF
--- a/autopilot/sagemaker_autopilot_direct_marketing.ipynb
+++ b/autopilot/sagemaker_autopilot_direct_marketing.ipynb
@@ -8,8 +8,6 @@
     "\n",
     "This notebook works well with the `Python 3 (Data Science)` kernel on SageMaker Studio.\n",
     "\n",
-    "---\n",
-    "\n",
     "---"
    ]
   },
@@ -64,7 +62,27 @@
    "source": [
     "## Prerequisites\n",
     "\n",
-    "In this first cell, we'll:\n",
+    "Before getting started, we'll check & upgrade a few installed library versions to avoid some past incompatibilities (see [numpy#18355](https://github.com/numpy/numpy/issues/18355) and [aiobotocore#905](https://github.com/aio-libs/aiobotocore/issues/905)).\n",
+    "\n",
+    "> ⚠️ **Note:** If you have any other notebooks running in the same Studio \"app\" (same kernel and instance type) that have already `import`ed these libraries into memory, you might see unexpected errors and need to restart those notebook kernels after this install."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "!pip install \"pandas>=1.0.5\" \"s3fs>=2022.01.0\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "With dependencies installed, this next code cell will:\n",
     "\n",
     "- **configure** the S3 bucket and folder where data should be stored (to keep our environment tidy)\n",
     "- **connect** to SageMaker with the open-source [Sagemaker Python SDK](https://sagemaker.readthedocs.io/en/stable/), `sagemaker`\n",
@@ -270,6 +288,16 @@
    "outputs": [],
    "source": [
     "automl_job.fit(inputs=train_data_s3_path, wait=False, logs=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Or if you need (e.g. after notebook restart), you can instead 'attach' to previous jobs by name:\n",
+    "# automl_job = automl.AutoML.attach(\"automl-2022-02-15-13-51-51-239\")"
    ]
   },
   {


### PR DESCRIPTION
**Issue #, if available:** N/A

**Description of changes:**

Add a `!pip` command to update pandas and s3fs in the autopilot notebook, to avoid compatibility issues in the current SMStudio Data Science kernel for some of the functions we use (e.g. read_csv from S3, and optionally using `df.info()`)

<br/>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
