### PR TITLE
Demo local script command in HuggingFace script mode example

### DIFF
--- a/custom_script_demos/huggingface_nlp/Headline Classifier Local.ipynb
+++ b/custom_script_demos/huggingface_nlp/Headline Classifier Local.ipynb
@@ -20,7 +20,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "7373d72c-7f09-4a87-851d-dc603412912b",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "%%html\n",
@@ -68,7 +70,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "efbe751a-dce5-4dd1-b96c-35738d28fe1e",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "%load_ext autoreload\n",
@@ -101,7 +105,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "131a0145-9033-4112-a67f-5e229679229e",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "%%time\n",
@@ -111,6 +117,10 @@
     "\n",
     "# Un-tar the AG News data.\n",
     "!tar zxf {local_dir}/ag_news_csv.tgz -C {local_dir}/ --strip-components=1 --no-same-owner\n",
+    "\n",
+    "# Push data partitions to separate subfolders, which is useful for local script debugging later\n",
+    "os.renames(f\"{local_dir}/test.csv\", f\"{local_dir}/test/test.csv\")\n",
+    "os.renames(f\"{local_dir}/train.csv\", f\"{local_dir}/train/train.csv\")\n",
     "print(\"Done!\")"
    ]
   },
@@ -126,12 +136,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "5369b9a2-c6f8-46ce-9b98-9451817be488",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "column_names = [\"CATEGORY\", \"TITLE\", \"CONTENT\"]\n",
     "# we use the train.csv only\n",
-    "df = pd.read_csv(f\"{local_dir}/train.csv\", names=column_names, header=None, delimiter=\",\")\n",
+    "df = pd.read_csv(f\"{local_dir}/train/train.csv\", names=column_names, header=None, delimiter=\",\")\n",
     "# shuffle the DataFrame rows\n",
     "df = df.sample(frac=1, random_state=1337)\n",
     "\n",
@@ -163,7 +175,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1a70b377-ee49-4780-8b32-57db4ee149ac",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "df[\"CATEGORY\"].value_counts()"
@@ -304,13 +318,13 @@
     "# Load the raw datasets:\n",
     "raw_train_dataset = datasets.load_dataset(\n",
     "    \"csv\",\n",
-    "    data_files=os.path.join(local_dir, \"train.csv\"),\n",
+    "    data_files=os.path.join(local_dir, \"train\", \"train.csv\"),\n",
     "    column_names=[\"category\", \"title\", \"content\"],\n",
     "    split=datasets.Split.ALL,\n",
     ")\n",
     "raw_test_dataset = datasets.load_dataset(\n",
     "    \"csv\",\n",
-    "    data_files=os.path.join(local_dir, \"test.csv\"),\n",
+    "    data_files=os.path.join(local_dir, \"test\", \"test.csv\"),\n",
     "    column_names=[\"category\", \"title\", \"content\"],\n",
     "    split=datasets.Split.ALL,\n",
     ")\n",
@@ -1014,6 +1028,26 @@
     "memoryGiB": 768,
     "name": "ml.g5.48xlarge",
     "vcpuNum": 192
+   },
+   {
+    "_defaultOrder": 55,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 8,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 1152,
+    "name": "ml.p4d.24xlarge",
+    "vcpuNum": 96
+   },
+   {
+    "_defaultOrder": 56,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 8,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 1152,
+    "name": "ml.p4de.24xlarge",
+    "vcpuNum": 96
    }
   ],
   "instance_type": "ml.t3.medium",

--- a/custom_script_demos/huggingface_nlp/Headline Classifier SageMaker.ipynb
+++ b/custom_script_demos/huggingface_nlp/Headline Classifier SageMaker.ipynb
@@ -64,7 +64,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "efbe751a-dce5-4dd1-b96c-35738d28fe1e",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "%load_ext autoreload\n",
@@ -96,7 +98,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "131a0145-9033-4112-a67f-5e229679229e",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "%%time\n",
@@ -106,6 +110,10 @@
     "\n",
     "# Un-tar the AG News data.\n",
     "!tar zxf {local_dir}/ag_news_csv.tgz -C {local_dir}/ --strip-components=1 --no-same-owner\n",
+    "\n",
+    "# Push data partitions to separate subfolders, which is useful for local script debugging later\n",
+    "os.renames(f\"{local_dir}/test.csv\", f\"{local_dir}/test/test.csv\")\n",
+    "os.renames(f\"{local_dir}/train.csv\", f\"{local_dir}/train/train.csv\")\n",
     "print(\"Done!\")"
    ]
   },
@@ -121,12 +129,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "5369b9a2-c6f8-46ce-9b98-9451817be488",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "column_names = [\"CATEGORY\", \"TITLE\", \"CONTENT\"]\n",
     "# we use the train.csv only\n",
-    "df = pd.read_csv(f\"{local_dir}/train.csv\", names=column_names, header=None, delimiter=\",\")\n",
+    "df = pd.read_csv(f\"{local_dir}/train/train.csv\", names=column_names, header=None, delimiter=\",\")\n",
     "# shuffle the DataFrame rows\n",
     "df = df.sample(frac=1, random_state=1337)\n",
     "\n",
@@ -158,7 +168,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1a70b377-ee49-4780-8b32-57db4ee149ac",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "df[\"CATEGORY\"].value_counts()"
@@ -190,11 +202,11 @@
     "\n",
     "s3 = boto3.resource(\"s3\")\n",
     "\n",
-    "s3.Bucket(bucket_name).upload_file(f\"{local_dir}/train.csv\", f\"{s3_prefix}/train/train.csv\")\n",
+    "s3.Bucket(bucket_name).upload_file(f\"{local_dir}/train/train.csv\", f\"{s3_prefix}/train/train.csv\")\n",
     "train_s3_uri = f\"s3://{bucket_name}/{s3_prefix}/train\"\n",
     "print(f\"train_s3_uri: {train_s3_uri}\")\n",
     "\n",
-    "s3.Bucket(bucket_name).upload_file(f\"{local_dir}/test.csv\", f\"{s3_prefix}/test/test.csv\")\n",
+    "s3.Bucket(bucket_name).upload_file(f\"{local_dir}/test/test.csv\", f\"{s3_prefix}/test/test.csv\")\n",
     "test_s3_uri = f\"s3://{bucket_name}/{s3_prefix}/test\"\n",
     "print(f\"test_s3_uri: {test_s3_uri}\")"
    ]
@@ -360,6 +372,44 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c25455f6-b3a6-450a-a7be-b5fa8f94f79d",
+   "metadata": {},
+   "source": [
+    "### (Optional) Testing your script\n",
+    "\n",
+    "> ℹ️ **Note:** This step is optional because in this example, the training script has already been built and tested for you!\n",
+    "\n",
+    "Although the job script [train.py](scripts/train.py) is mainly the same logic and process as previously done in the notebook itself, of course it would be good to **test** the adaptations we made to prepare it for SageMaker.\n",
+    "\n",
+    "For initial functional testing and debugging of your script, you may not want to spin up a full SageMaker training job each time: Because of the short delay while each new job spins up its on-demand compute resources.\n",
+    "\n",
+    "There are multiple ways you can speed up this process. We'd usually recommend [SageMaker Warm Pools](https://docs.aws.amazon.com/sagemaker/latest/dg/train-warm-pools.html) or [SageMaker Local Mode](https://sagemaker.readthedocs.io/en/stable/overview.html?#local-mode), but these aren't available in the standard workshop environment. Instead, you can **simulate a training job within the notebook** by invoking your training script through CLI.\n",
+    "\n",
+    "You can un-comment (with `Ctrl`+`/`) and run the cell below to try this - ⚠️ but watch out: It's quite memory-intensive, so you'll want to shut down or restart the kernel from the previous [Headline Classifier Local notebook](Headline%20Classifier%20Local.ipynb) first."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f14873a8-9a90-41a7-b5fc-9a88041a577d",
+   "metadata": {
+    "scrolled": true,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# class_names_str = \",\".join(class_names)  # Comma-separated list for CLI\n",
+    "# !python3 scripts/train.py \\\n",
+    "#     --train data/train \\\n",
+    "#     --test data/test \\\n",
+    "#     --output_data_dir data/local-output \\\n",
+    "#     --model_dir data/local-model \\\n",
+    "#     --model_id=amazon/bort --class_names={class_names_str} --train_max_steps=20 \\\n",
+    "#     --train_batch_size=8 --eval_batch_size=16 --fp16=0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "e2d648ba-8214-423e-926d-1417d56e413c",
    "metadata": {},
    "source": [
@@ -401,7 +451,7 @@
     "    instance_type=\"ml.p3.2xlarge\",  # Type of compute instance to use: p* and g* include GPUs\n",
     "    role=nb_role,  # IAM role the job will use to access AWS resources (e.g. data on S3)\n",
     "\n",
-    "    hyperparameters= hyperparameters,   # Training job parameters, as we set up earlier\n",
+    "    hyperparameters=hyperparameters,   # Training job parameters, as we set up earlier\n",
     "    metric_definitions=metric_definitions,  # RegEx to extract metric data from training job logs\n",
     ")"
    ]
@@ -1206,6 +1256,26 @@
     "memoryGiB": 768,
     "name": "ml.g5.48xlarge",
     "vcpuNum": 192
+   },
+   {
+    "_defaultOrder": 55,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 8,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 1152,
+    "name": "ml.p4d.24xlarge",
+    "vcpuNum": 96
+   },
+   {
+    "_defaultOrder": 56,
+    "_isFastLaunch": false,
+    "category": "Accelerated computing",
+    "gpuNum": 8,
+    "hideHardwareSpecs": false,
+    "memoryGiB": 1152,
+    "name": "ml.p4de.24xlarge",
+    "vcpuNum": 96
    }
   ],
   "instance_type": "ml.t3.medium",


### PR DESCRIPTION
Demonstrate running the HuggingFace NLP training script locally in the 'SageMaker' mode example notebook, to illustrate the workflow for debugging the script before running in SageMaker.

**Issue #, if available:** #33 (partial)

**Description of changes:**

Adjust the Hugging Face script mode example to support running the `train.py` locally on the notebook via `!python` command, and add the example command to the SageMaker mode notebook.

The code is commented out to avoid running by default, because the nb will run out of memory unless the previous 'Local Mode' kernel is killed: Training BORT is too memory-intensive to have 2 copies open on a t3.medium!

<br/>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
