### PR TITLE
Update migration challenge PyTorch instruction notebook:

### DIFF
--- a/migration_challenge/pytorch_mnist/Instructions.ipynb
+++ b/migration_challenge/pytorch_mnist/Instructions.ipynb
@@ -210,7 +210,7 @@
    "outputs": [],
    "source": [
     "# TODO: Define your 2 data channels\n",
-    "# The data can be found in: \"s3://{bucket_name}/mnist/train\" and \"s3://{bucket_name}/mnist/test\"\n",
+    "# The data can be found in: \"s3://{bucket_name}/mnist/training\" and \"s3://{bucket_name}/mnist/testing\"\n",
     "\n",
     "inputs = # Look at the previous example to see how the inputs were defined"
    ]


### PR DESCRIPTION
Correct S3 data folder name in TODO comment

*Issue #, if available:*
N/A

*Description of changes:*
In `/migration_challenge/pytorch_mnist/Instructions.ipynb`, the TODO code cell under Data Input("Channels") Configuration says 
```
# The data can be found in: "s3://{bucket_name}/mnist/train" and "s3://{bucket_name}/mnist/test"
```
But as set up in earlier code cells, the folder names should be `"s3://{bucket_name}/mnist/training"` and `"s3://{bucket_name}/mnist/testing"`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
